### PR TITLE
Keep in sync the resolver implementations with the refactor of its SPI

### DIFF
--- a/src/main/java/io/vertx/serviceresolver/srv/impl/SrvServiceState.java
+++ b/src/main/java/io/vertx/serviceresolver/srv/impl/SrvServiceState.java
@@ -14,10 +14,10 @@ import java.util.List;
 
 class SrvServiceState<B> {
 
-  final List<B> endpoints;
+  final B endpoints;
   final long expirationMs;
 
-  public SrvServiceState(List<B> endpoints, long expirationMs) {
+  public SrvServiceState(B endpoints, long expirationMs) {
     this.endpoints = endpoints;
     this.expirationMs = expirationMs;
   }

--- a/src/test/java/mock/MockResolver.java
+++ b/src/test/java/mock/MockResolver.java
@@ -4,6 +4,7 @@ import io.vertx.core.Future;
 import io.vertx.core.net.Address;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.resolver.address.AddressResolver;
+import io.vertx.core.spi.resolver.address.EndpointListBuilder;
 import io.vertx.serviceresolver.impl.*;
 import io.vertx.serviceresolver.ServiceAddress;
 import io.vertx.serviceresolver.ServiceResolver;
@@ -47,7 +48,7 @@ public class MockResolver<B> implements AddressResolver<ServiceAddress, SocketAd
   }
 
   @Override
-  public Future<MockServiceState<B>> resolve(Function<SocketAddress, B> factory, ServiceAddress address) {
+  public Future<MockServiceState<B>> resolve(ServiceAddress address, EndpointListBuilder<B, SocketAddress> builder) {
     List<SocketAddress> endpoints = templates.get(address.name());
     if (endpoints == null) {
       return Future.failedFuture("No addresses for service svc");


### PR DESCRIPTION
The address resolver SPI has been refactored to enable hashed key based routing.

This keep in sync the resolver implementations with the refactor.
