### PR TITLE
Kindcontainer should be in compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
       <groupId>com.dajudge.kindcontainer</groupId>
       <artifactId>kindcontainer</artifactId>
       <version>1.4.3</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>


### PR DESCRIPTION
com.dajudge.kindcontainer:kindcontainer is only used for tests and shouldn't be brought transitively to user projects.