### PR TITLE
The kube resolver should set the endpoints when the subsets json structure is not present

### DIFF
--- a/src/main/java/io/vertx/serviceresolver/kube/impl/KubeServiceState.java
+++ b/src/main/java/io/vertx/serviceresolver/kube/impl/KubeServiceState.java
@@ -98,8 +98,8 @@ class KubeServiceState<B> {
     String name = metadata.getString("name");
     if (this.name.equals(name)) {
       JsonArray subsets = item.getJsonArray("subsets");
+      EndpointBuilder<B, SocketAddress> builder = endpointsBuilder;
       if (subsets != null) {
-        EndpointBuilder<B, SocketAddress> builder = endpointsBuilder;
         for (int j = 0;j < subsets.size();j++) {
           List<String> podIps = new ArrayList<>();
           JsonObject subset = subsets.getJsonObject(j);
@@ -119,8 +119,8 @@ class KubeServiceState<B> {
             }
           }
         }
-        this.endpoints.set(builder.build());
       }
+      this.endpoints.set(builder.build());
     }
   }
 }

--- a/src/test/java/io/vertx/tests/kube/KubeServiceResolverMockTest.java
+++ b/src/test/java/io/vertx/tests/kube/KubeServiceResolverMockTest.java
@@ -16,6 +16,9 @@ import org.junit.Test;
 import java.net.InetAddress;
 import java.util.*;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 public class KubeServiceResolverMockTest extends KubeServiceResolverTestBase {
 
   @Rule

--- a/src/test/java/io/vertx/tests/kube/KubeServiceResolverTestBase.java
+++ b/src/test/java/io/vertx/tests/kube/KubeServiceResolverTestBase.java
@@ -9,7 +9,11 @@ import io.vertx.tests.ServiceResolverTestBase;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public abstract class KubeServiceResolverTestBase extends ServiceResolverTestBase {
 
@@ -104,7 +108,19 @@ public abstract class KubeServiceResolverTestBase extends ServiceResolverTestBas
     }
   }
 
-/*
+  @Test
+  public void testEmptyPods() throws Exception {
+    String serviceName = "svc";
+    kubernetesMocking.buildAndRegisterKubernetesService(serviceName, kubernetesMocking.defaultNamespace(), KubeOp.CREATE, Collections.emptyList());
+    try {
+      get(ServiceAddress.of("svc"));
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals("No results for svc", e.getMessage());
+    }
+  }
+
+  /*
   @Test
   public void testDispose(TestContext should) throws Exception {
     Handler<HttpServerRequest> server = req -> {


### PR DESCRIPTION
Motivation:

The kube resolver sets the list of endpoints (pods) from the subsets member of the endpoints json object.

When the service does not have any pods, the subsets member is absent and causes an NPE downstream in the resolver assuming the endpoints list is never null.

Changes:

Always set the list of endpoints to consistently populate the list.
