### PR TITLE
Reimplement Kubernetes resolver WebSocket failures

### DIFF
--- a/src/test/java/io/vertx/tests/kube/KubeServiceResolverTestBase.java
+++ b/src/test/java/io/vertx/tests/kube/KubeServiceResolverTestBase.java
@@ -136,7 +136,7 @@ public abstract class KubeServiceResolverTestBase extends ServiceResolverTestBas
   }
 
   @Test
-  public void testReconnectWebSocket(TestContext should) throws Exception {
+  public void testWebSocketClose(TestContext should) throws Exception {
     Handler<HttpServerRequest> server = req -> {
       req.response().end("" + req.localAddress().port());
     };
@@ -148,11 +148,10 @@ public abstract class KubeServiceResolverTestBase extends ServiceResolverTestBas
     assertWaitUntil(() -> proxy.webSockets().size() == 1);
     WebSocketBase ws = proxy.webSockets().iterator().next();
     ws.close();
-    assertWaitUntil(() -> proxy.webSockets().size() == 1 && !proxy.webSockets().contains(ws));
+    assertWaitUntil(() -> !proxy.webSockets().contains(ws));
     kubernetesMocking.buildAndRegisterKubernetesService(service, kubernetesMocking.defaultNamespace(), KubeOp.UPDATE, pods);
     checkEndpoints(service, "8080", "8081");
   }
-
   /*
   @Test
   public void testDispose(TestContext should) throws Exception {


### PR DESCRIPTION
Motivation:
    
The implementation of the Kubernetes resolver relies on watching a Kubernetes resource through a WebSocket to maintain its state. When the WebSocket fails, a reconnection is attemped which might fails, in particular the server might respond with a 410 GONE response indicating the the watched resource is not available anymore.
    
 We could handle such failure in the resolver itself and perform a new GET then Watch operation, but it turns out that the endpoint resolver implements this already.
    
 Changes:
    
 When the resolver resolves a service, make the WebSocket connect part of the resolution and not a side effect of the resolution, hence if the WebSocket cannot connect, the resolution fails and the HTTP client reacts accordingly.
    
 When the WebSocket is disconnected, mark the kube service state as invalid, this state is probed by the HTTP client and will attempt a new resolution leading to a new GET then Watch sequence in the resolver.