### PR TITLE
Kubernetes token provider

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -128,10 +128,15 @@ The default resolver options values are loaded from the pod environment
 
 You can override these settings.
 
+You can deal with ephemeral tokens using the {@link io.vertx.serviceresolver.kube.KubeResolver#tokenProvider}.
+
 [source,java]
 ----
-{@link examples.ServiceResolverExamples#configuringKubernetesResolver}
+{@link examples.ServiceResolverExamples#usingKubernetesTokenProvider}
 ----
+
+The resolver calls the provider when it needs a fresh token. The token is cached by the resolver until it is detetected
+stale by the resolver (upon a `401` server response code).
 
 === SRV resolver
 

--- a/src/main/java/examples/ServiceResolverExamples.java
+++ b/src/main/java/examples/ServiceResolverExamples.java
@@ -28,6 +28,7 @@ import io.vertx.serviceresolver.srv.SrvResolver;
 import io.vertx.serviceresolver.srv.SrvResolverOptions;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 @Source
 public class ServiceResolverExamples {
@@ -108,7 +109,23 @@ public class ServiceResolverExamples {
 
     KubeResolverOptions options = new KubeResolverOptions();
 
-    AddressResolver resolver = KubeResolver.create(options);
+    KubeResolver resolver = KubeResolver.create(options);
+
+    HttpClient client = vertx.httpClientBuilder()
+      .withAddressResolver(resolver)
+      .build();
+  }
+
+  private static String loadToken() {
+    return "the-token";
+  }
+
+  public void usingKubernetesTokenProvider(Vertx vertx) {
+
+    KubeResolverOptions options = new KubeResolverOptions();
+
+    KubeResolver resolver = KubeResolver.create(options)
+      .tokenProvider(() -> loadToken());
 
     HttpClient client = vertx.httpClientBuilder()
       .withAddressResolver(resolver)

--- a/src/main/java/io/vertx/serviceresolver/kube/KubeResolver.java
+++ b/src/main/java/io/vertx/serviceresolver/kube/KubeResolver.java
@@ -11,20 +11,22 @@
 package io.vertx.serviceresolver.kube;
 
 import io.vertx.core.net.AddressResolver;
-import io.vertx.serviceresolver.impl.ServiceAddressResolver;
-import io.vertx.serviceresolver.kube.impl.KubeResolverImpl;
+import io.vertx.serviceresolver.ServiceAddress;
+import io.vertx.serviceresolver.kube.impl.KubeAddressResolver;
+
+import java.util.function.Supplier;
 
 /**
  * A resolver for services within a Kubernetes cluster.
  */
-public interface KubeResolver {
+public interface KubeResolver extends AddressResolver<ServiceAddress> {
 
   /**
    * Create a Kubernetes resolver with the default options.
    *
    * @return the resolver
    */
-  static AddressResolver create() {
+  static KubeResolver create() {
     return create(new KubeResolverOptions());
   }
 
@@ -33,7 +35,17 @@ public interface KubeResolver {
    *
    * @return the resolver
    */
-  static AddressResolver create(KubeResolverOptions options) {
-    return new ServiceAddressResolver((vertx, lookup) -> new KubeResolverImpl(vertx, options));
+  static KubeResolver create(KubeResolverOptions options) {
+    return new KubeAddressResolver(options);
   }
+
+  /**
+   * Set a token provider for the resolver: the {@code tokenProvider} supplier is called when the resolver
+   * needs a token or retries when the server responses with a {@code 401} code.
+   *
+   * @param tokenProvider the token provider called when a bearer token is needed
+   * @return this instance
+   */
+  KubeResolver tokenProvider(Supplier<String> tokenProvider);
+
 }

--- a/src/main/java/io/vertx/serviceresolver/kube/impl/KubeAddressResolver.java
+++ b/src/main/java/io/vertx/serviceresolver/kube/impl/KubeAddressResolver.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.serviceresolver.kube.impl;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.net.AddressResolver;
+import io.vertx.core.spi.endpoint.EndpointResolver;
+import io.vertx.serviceresolver.ServiceAddress;
+import io.vertx.serviceresolver.kube.KubeResolver;
+import io.vertx.serviceresolver.kube.KubeResolverOptions;
+
+import java.util.function.Supplier;
+
+public class KubeAddressResolver implements KubeResolver {
+
+  private final KubeResolverOptions options;
+  private Supplier<String> tokenProvider;
+
+  public KubeAddressResolver(KubeResolverOptions options) {
+    this.options = options;
+  }
+
+  @Override
+  public EndpointResolver<ServiceAddress, ?, ?, ?> endpointResolver(Vertx vertx) {
+    Supplier<String> tokenProvider = this.tokenProvider;
+    if (tokenProvider == null) {
+      String token = options.getBearerToken();
+      if (token != null) {
+        if (token.equals(KubeResolverOptions.DEFAULT_TOKEN)) {
+          // Special case
+          tokenProvider = () -> KubeResolverImpl.defaultToken().orElse(null);
+        } else {
+          tokenProvider = () -> token;
+        }
+      } else {
+        tokenProvider = null;
+      }
+    }
+    return new KubeResolverImpl<>(vertx, tokenProvider, options);
+  }
+
+  @Override
+  public KubeResolver tokenProvider(Supplier<String> tokenProvider) {
+    this.tokenProvider = tokenProvider;
+    return this;
+  }
+}

--- a/src/main/java/io/vertx/serviceresolver/kube/impl/KubeResolverImpl.java
+++ b/src/main/java/io/vertx/serviceresolver/kube/impl/KubeResolverImpl.java
@@ -12,7 +12,10 @@ package io.vertx.serviceresolver.kube.impl;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.Address;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.endpoint.EndpointBuilder;
@@ -20,17 +23,42 @@ import io.vertx.core.spi.endpoint.EndpointResolver;
 import io.vertx.serviceresolver.ServiceAddress;
 import io.vertx.serviceresolver.kube.KubeResolverOptions;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 public class KubeResolverImpl<B> implements EndpointResolver<ServiceAddress, SocketAddress, KubeServiceState<B>, B> {
 
+  public static final String KUBERNETES_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
+  public static final String KUBERNETES_SERVICE_PORT = "KUBERNETES_SERVICE_PORT";
+  public static final String KUBERNETES_SERVICE_ACCOUNT_TOKEN = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+  public static final String KUBERNETES_SERVICE_ACCOUNT_CA = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+  public static final String KUBERNETES_SERVICE_ACCOUNT_NAMESPACE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+  public static Optional<String> defaultToken() {
+    File tokenFile = new File(KUBERNETES_SERVICE_ACCOUNT_TOKEN);
+    if (tokenFile.exists()) {
+      try {
+        String token = Buffer.buffer(Files.readAllBytes(tokenFile.toPath())).toString();
+        return Optional.of(token);
+      } catch (IOException ignore) {
+      }
+    }
+    return Optional.empty();
+  }
+
   final KubeResolverOptions options;
+  final Supplier<String> tokenProvider;
   final SocketAddress server;
   Vertx vertx;
   WebSocketClient wsClient;
   HttpClient httpClient;
   final String namespace;
-  final String bearerToken;
+  private String cachedToken;
 
-  public KubeResolverImpl(Vertx vertx, KubeResolverOptions options) {
+  public KubeResolverImpl(Vertx vertx, Supplier<String> tokenProvider, KubeResolverOptions options) {
 
     HttpClientOptions httpClientOptions = options.getHttpClientOptions();
     WebSocketClientOptions wsClientOptions = options.getWebSocketClientOptions();
@@ -41,7 +69,7 @@ public class KubeResolverImpl<B> implements EndpointResolver<ServiceAddress, Soc
     this.options = options;
     this.namespace = options.getNamespace();
     this.server = options.getServer();
-    this.bearerToken = options.getBearerToken();
+    this.tokenProvider = tokenProvider;
   }
 
   @Override
@@ -49,12 +77,109 @@ public class KubeResolverImpl<B> implements EndpointResolver<ServiceAddress, Soc
     return address instanceof ServiceAddress ? (ServiceAddress) address : null;
   }
 
+  private synchronized String token() {
+    String token = cachedToken;
+    if (token == null) {
+      if (tokenProvider != null) {
+        token = tokenProvider.get();
+        if (token != null) {
+          cachedToken = token;
+        }
+      }
+    }
+    return token;
+  }
+
+  private synchronized void setToken(String token) {
+    this.cachedToken = token;;
+  }
+
+  private static class EndpoinsRequest<T> {
+    final T payload;
+    final String token;
+    final int retries;
+    EndpoinsRequest(T payload, String token, int retries) {
+      this.payload = payload;
+      this.token = token;
+      this.retries = retries;
+    }
+  }
+
+  Future<EndpoinsRequest<JsonObject>> requestEndpoints(String token, int retries) {
+    return httpClient
+      .request(new RequestOptions()
+        .setMethod(HttpMethod.GET)
+        .setServer(server)
+        .setURI("/api/v1/namespaces/" + namespace + "/endpoints"))
+      .compose(req -> {
+        if (token != null) {
+          req.putHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+        return req.send().compose(resp -> {
+          if (resp.statusCode() == 200) {
+            return resp.body().map(body -> new EndpoinsRequest<>(new JsonObject(body), token, retries));
+          } else if (resp.statusCode() == 401) {
+            // It could be an expired token
+            if (tokenProvider != null && retries < 3) {
+              String freshToken = tokenProvider.get();
+              if (freshToken != null && !freshToken.equals(token)) {
+                return requestEndpoints(freshToken, retries + 1);
+              }
+            }
+          }
+          return resp.body().transform(ar -> {
+            StringBuilder msg = new StringBuilder("Invalid status code " + resp.statusCode());
+            if (ar.succeeded()) {
+              msg.append(" : ").append(ar.result().toString());
+            }
+            return Future.failedFuture(msg.toString());
+          });
+        });
+      });
+  }
+
   @Override
   public Future<KubeServiceState<B>> resolve(ServiceAddress address, EndpointBuilder<B, SocketAddress> builder) {
-    KubeServiceState<B> state = new KubeServiceState<>(builder, this, address, vertx, address.name());
-    return state
-      .connect()
-      .map(state);
+    String token = token();
+    Future<EndpoinsRequest<JsonObject>> endpointsFuture = requestEndpoints(token, 0);
+    return endpointsFuture
+      .compose(endpointsRequest -> {
+        KubeServiceState<B> state = new KubeServiceState<>(builder, address.name());
+        JsonObject response = endpointsRequest.payload;
+        String resourceVersion = response.getJsonObject("metadata").getString("resourceVersion");
+        JsonArray items = response.getJsonArray("items");
+        for (int i = 0; i < items.size(); i++) {
+          JsonObject item = items.getJsonObject(i);
+          state.updateEndpoints(item);
+        }
+        if (endpointsRequest.token != null && !endpointsRequest.token.equals(token)) {
+          setToken(endpointsRequest.token);
+        }
+        return connectWebSocket(state, resourceVersion, endpointsRequest.token).map(state);
+      });
+  }
+
+  private Future<WebSocket> connectWebSocket(KubeServiceState<B> state, String resourceVersion, String token) {
+    String requestURI = "/api/v1/namespaces/" + namespace + "/endpoints?"
+      + "watch=true"
+      + "&"
+      + "allowWatchBookmarks=true"
+      + "&"
+      + "resourceVersion=" + resourceVersion;
+    WebSocketConnectOptions connectOptions = new WebSocketConnectOptions();
+    connectOptions.setServer(server);
+    connectOptions.setURI(requestURI);
+    if (token != null) {
+      connectOptions.putHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+    }
+    return wsClient.webSocket()
+      .handler(buff -> {
+        JsonObject update  = buff.toJsonObject();
+        state.handleUpdate(update);
+      })
+      .closeHandler(v -> {
+        state.valid = false;
+      }).connect(connectOptions);
   }
 
   @Override
@@ -76,8 +201,8 @@ public class KubeResolverImpl<B> implements EndpointResolver<ServiceAddress, Soc
   @Override
   public void dispose(KubeServiceState<B> unused) {
     unused.disposed = true;
-    if (unused.ws != null) {
-      unused.ws.close();
+    if (unused.webSocket != null) {
+      unused.webSocket.close();
     }
   }
 

--- a/src/main/java/io/vertx/serviceresolver/kube/impl/KubeServiceState.java
+++ b/src/main/java/io/vertx/serviceresolver/kube/impl/KubeServiceState.java
@@ -10,95 +10,29 @@
  */
 package io.vertx.serviceresolver.kube.impl;
 
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.*;
+import io.vertx.core.http.WebSocket;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.endpoint.EndpointBuilder;
-import io.vertx.serviceresolver.ServiceAddress;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.vertx.core.http.HttpMethod.GET;
-
 class KubeServiceState<B> {
 
   final String name;
-  final Vertx vertx;
-  final KubeResolverImpl<B> resolver;
   final EndpointBuilder<B, SocketAddress> endpointsBuilder;
-  final ServiceAddress address;
   boolean disposed;
-  WebSocket ws;
+  WebSocket webSocket;
   AtomicReference<B> endpoints = new AtomicReference<>();
   volatile boolean valid;
 
-  KubeServiceState(EndpointBuilder<B, SocketAddress> endpointsBuilder,
-                   KubeResolverImpl<B> resolver,
-                   ServiceAddress address,
-                   Vertx vertx,
-                   String name) {
+  KubeServiceState(EndpointBuilder<B, SocketAddress> endpointsBuilder, String name) {
     this.endpointsBuilder = endpointsBuilder;
     this.name = name;
-    this.resolver = resolver;
-    this.vertx = vertx;
-    this.address = address;
     this.valid = true;
-  }
-
-  Future<?> connect() {
-    RequestOptions options = new RequestOptions()
-      .setMethod(GET)
-      .setServer(resolver.server)
-      .setURI("/api/v1/namespaces/" + resolver.namespace + "/endpoints");
-    if (resolver.bearerToken != null) {
-      options.putHeader(HttpHeaders.AUTHORIZATION, "Bearer " + resolver.bearerToken); // Todo concat that ?
-    }
-    return resolver.httpClient
-      .request(options)
-      .compose(request -> request
-        .send()
-        .expecting(HttpResponseExpectation.SC_OK)
-        .compose(response -> response
-          .body()
-          .map(Buffer::toJsonObject)))
-      .compose(response -> {
-        String resourceVersion = response.getJsonObject("metadata").getString("resourceVersion");
-        JsonArray items = response.getJsonArray("items");
-        for (int i = 0;i < items.size();i++) {
-          JsonObject item = items.getJsonObject(i);
-          updateEndpoints(item);
-        }
-        return connectWebSocket(resourceVersion);
-      });
-  }
-
-  Future<?> connectWebSocket(String resourceVersion) {
-    String requestURI = "/api/v1/namespaces/" + resolver.namespace + "/endpoints?"
-      + "watch=true"
-      + "&"
-      + "allowWatchBookmarks=true"
-      + "&"
-      + "resourceVersion=" + resourceVersion;
-    WebSocketConnectOptions connectOptions = new WebSocketConnectOptions();
-    connectOptions.setServer(resolver.server);
-    connectOptions.setURI(requestURI);
-    if (resolver.bearerToken != null) {
-      connectOptions.putHeader(HttpHeaders.AUTHORIZATION, "Bearer " + resolver.bearerToken);
-    }
-    return resolver.wsClient.webSocket()
-      .handler(buff -> {
-        JsonObject update  = buff.toJsonObject();
-        handleUpdate(update);
-      })
-      .closeHandler(v -> {
-        valid = false;
-      }).connect(connectOptions);
   }
 
   void handleUpdate(JsonObject update) {
@@ -115,7 +49,7 @@ class KubeServiceState<B> {
     }
   }
 
-  private void updateEndpoints(JsonObject item) {
+  void updateEndpoints(JsonObject item) {
     JsonObject metadata = item.getJsonObject("metadata");
     String name = metadata.getString("name");
     if (this.name.equals(name)) {


### PR DESCRIPTION
Motivation:

Support dynamic token resolution for Kubernetes resolver, since tokens can be ephemeral.

Changes:

Update the resolver creation with a token provider called initially and upon 401 errors.
