### PR TITLE
Fixed NPE in updateEndpoints when endpoints update event does not contain addresses array

### DIFF
--- a/src/main/java/io/vertx/serviceresolver/kube/impl/KubeServiceState.java
+++ b/src/main/java/io/vertx/serviceresolver/kube/impl/KubeServiceState.java
@@ -64,10 +64,14 @@ class KubeServiceState<B> {
           JsonObject subset = subsets.getJsonObject(j);
           JsonArray addresses = subset.getJsonArray("addresses");
           JsonArray ports = subset.getJsonArray("ports");
-          for (int k = 0;k < addresses.size();k++) {
-            JsonObject address = addresses.getJsonObject(k);
-            String ip = address.getString("ip");
-            podIps.add(ip);
+          // Addresses array can be null when service pods are getting ready slowly
+          // and are first added to notReadyAddresses array.
+          if (addresses != null) {
+            for (int k = 0;k < addresses.size();k++) {
+              JsonObject address = addresses.getJsonObject(k);
+              String ip = address.getString("ip");
+              podIps.add(ip);
+            }
           }
           for (int k = 0;k < ports.size();k++) {
             JsonObject port = ports.getJsonObject(k);


### PR DESCRIPTION
Fixes #21, cherry-picked from https://github.com/eclipse-vertx/vertx-service-resolver/pull/29

Motivation:

I've got modification event from K8S without addresses array filled and just with notReadyAddresses:
```
{
  "type": "MODIFIED",
  "object": {
    "kind": "Endpoints",
    "apiVersion": "v1",
    "metadata": {
      "name": "frontend-1",
      "namespace": "api",
      "uid": "f7ddf126-e06c-4b8c-a401-5e17b163ac50",
      "resourceVersion": "27159",
      "creationTimestamp": "2025-10-30T12:18:36Z",
      "labels": {
        "app": "routing-api",
        "id": "1",
        "instance": "frontend-1",
        "name": "frontend"
      },
      "managedFields": [
        {
          "manager": "kube-controller-manager",
          "operation": "Update",
          "apiVersion": "v1",
          "time": "2025-10-30T13:03:17Z",
          "fieldsType": "FieldsV1",
          "fieldsV1": {
            "f:metadata": {
              "f:labels": {
                ".": {},
                "f:app": {},
                "f:id": {},
                "f:instance": {},
                "f:name": {}
              }
            },
            "f:subsets": {}
          }
        }
      ]
    },
    "subsets": [
      {
        "notReadyAddresses": [
          {
            "ip": "10.240.0.234",
            "nodeName": "aks-nkwpool-18983291-vmss000006",
            "targetRef": {
              "kind": "Pod",
              "namespace": "api",
              "name": "nkw-service-deployment-1-69d55c55b8-sgvml",
              "uid": "824bca44-2883-443b-b2d4-98c535c26f81"
            }
          }
        ],
        "ports": [
          {
            "name": "http",
            "port": 6599,
            "protocol": "TCP"
          }
        ]
      }
    ]
  }
}
```

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
